### PR TITLE
Adiciona container de banco de dados e integra com container de aplicação

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,11 @@
+volumes:
+  # Volume para armazenar arquivos do banco de dados.
+  db_data:
+
+networks:
+  # Rede interna entre os containers.
+  internal:
+
 services:
   # Container com a API baseada em NestJS.
   api:
@@ -8,11 +16,48 @@ services:
       # Arquivo de definição da imagem do container.
       dockerfile: docker/api/Dockerfile
     ports:
-      # Expondo aplicação na porta 5000.
-      - "5000:5000"
+      # Expondo aplicação na porta especificada na variável de ambiente PORT.
+      - "${PORT}:${PORT}"
+    environment:
+      PORT: "${PORT}"
+      ENV: "${ENV}"
+      POSTGRES_HOST: db
+      POSTGRES_PORT: 5432
+      POSTGRES_USER: "${POSTGRES_USER}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
+      POSTGRES_DATABASE: "${POSTGRES_DATABASE}"
+    restart: unless-stopped
+    networks:
+      - internal
+    depends_on:
+      # Espera até que o banco de dados esteja pronto para receber requisições para iniciar a aplicação.
+      db:
+        condition: service_healthy
     # Define health check simples que só testa se o endpoint padrão está respondendo requisições.
     healthcheck:
-      test: curl -k -f http://localhost:5000
+      test: "curl -k -f http://localhost:${PORT}"
       interval: 10s
       timeout: 10s
       retries: 10
+  db:
+    image: postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: "${POSTGRES_DATABASE}"
+      POSTGRES_USER: "${POSTGRES_USER}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
+    # Se você quer acessar o banco de dados por uma ferramenta externa, descomente as duas linhas seguintes para exportar o
+    # postgres na porta 5432 do host (ou ajuste a porta que deseja mapear do host).
+    ports:
+      - "5432:5432"
+    networks:
+      - internal
+    volumes:
+      # Monta volume para a pasta de dados do postgresql.
+      - db_data:/var/lib/postgresql/data
+    # Define health check quer verifica se o banco de dados está pronto para receber requisições.
+    healthcheck:
+      test: [ "CMD-SHELL", "sh -c 'pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DATABASE}'" ]
+      interval: 10s
+      timeout: 3s
+      retries: 3

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "start:prod:docker": "docker compose up -d --build",
+    "start:docker": "docker compose --env-file envs/.env.prod  up -d --build ",
+    "stop:docker": "docker compose --env-file envs/.env.prod down",
+    "purge:docker": "docker compose --env-file envs/.env.prod down -v",
     "stop:prod:docker": "docker compose down"
   },
   "dependencies": {


### PR DESCRIPTION
## Descrição

Com a essa mudança é possível executar a api conectada a uma instância de banco de dados postgresql. Para que isso funcione é preciso definir um arquivo `.env.prod` na pasta envs com base no arquivo de template na mesma pasta. Três novos comandos foram definidos no package.json para ajudar na execução da aplicação no ambiente docker:

- `npm run start:docker`: Inicializa a aplicação da api e um container de banco de dados integrados.
- `npm run stop:docker`: Desliga os containers da aplicação e banco de dados sem destruir os volumes associados aos containers. Então os dados escritos no banco são mantidos.
- `npm run purge:docker`: Desliga os containers da aplicação e banco de dados. Este comando também descarta os volumes associados aos containers, então todo os dados gerados pela aplicação, são perdidos. Este comando é útil quando se deseja reinicilizar a aplicação com o banco de dados limpo.

A composição de containers foi construída de forma que o container da api espera até que o banco de dados esteja pronto para receber conexões antes de iniciar a operação, o que garante a correta conexão com o banco.

## Como a mudança foi testada?
Eu defini o arquivo `envs/.env.prod` com o seguinte conteúdo:

```
ENV=local
PORT=3000
POSTGRES_HOST=localhost
POSTGRES_PORT=5432
POSTGRES_USER=postgres
POSTGRES_PASSWORD=postgres
POSTGRES_DATABASE=fiap-project
```

Em seguida executei o comando `npm run start:docker`. Então os containers de banco de dados e da aplicação são iniciados. Então foi possível acessar a aplicaçãom em `http://localhost:3000/api`.